### PR TITLE
feat: namespaces to scoped

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,12 +19,6 @@ dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 csharp_using_directive_placement = inside_namespace:none
 
-# Always use "this." and "Me." when applicable; let StyleCop Analyzers provide the warning and fix
-dotnet_style_qualification_for_field = true:none
-dotnet_style_qualification_for_property = true:none
-dotnet_style_qualification_for_method = true:none
-dotnet_style_qualification_for_event = true:none
-
 # Use language keywords where applicable; let StyleCop Analyzers provide the warning and fix
 dotnet_style_predefined_type_for_locals_parameters_members = true:none
 dotnet_style_predefined_type_for_member_access = true:none

--- a/Sample.Struct/Enumerables/ArrayEnumerable.cs
+++ b/Sample.Struct/Enumerables/ArrayEnumerable.cs
@@ -1,28 +1,44 @@
-using Sample.Struct.Summators;
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
+using Summators;
 
-namespace Sample.Struct.Enumerables
+public static class ArrayEnumerable
 {
-    public static class ArrayEnumerable
+    public static Enumerable<T, ArrayEnumerator<T>, ArrayEnumerable<T>> AsStructEnumerable<T>(this T[] list)
     {
-        public static Enumerable<T, ArrayEnumerator<T>, ArrayEnumerable<T>> AsStructEnumerable<T>(this T[] list)
-            => new ArrayEnumerable<T>(list);
-
-        public static Linqable<int, ArrayEnumerator<int>, ArrayEnumerable<int>, IntSummator> AsStructLinqable(this int[] list)
-            => new ArrayEnumerable<int>(list);
+        return new ArrayEnumerable<T>(list);
     }
 
-    public readonly struct ArrayEnumerable<T> : IEnumerable<T, ArrayEnumerator<T>>
+    public static Linqable<int, ArrayEnumerator<int>, ArrayEnumerable<int>, IntSummator> AsStructLinqable(
+        this int[] list)
     {
-        internal ArrayEnumerable(T[] value) => Value = value;
+        return new ArrayEnumerable<int>(list);
+    }
+}
 
-        public T[] Value { get; }
+public readonly struct ArrayEnumerable<T> : IEnumerable<T, ArrayEnumerator<T>>
+{
+    internal ArrayEnumerable(T[] value)
+    {
+        this.Value = value;
+    }
 
-        public ArrayEnumerator<T> GetEnumerator() => new ArrayEnumerator<T>(Value);
+    public T[] Value { get; }
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+    public ArrayEnumerator<T> GetEnumerator()
+    {
+        return new ArrayEnumerator<T>(this.Value);
+    }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/ArrayEnumerable.cs
+++ b/Sample.Struct/Enumerables/ArrayEnumerable.cs
@@ -22,23 +22,23 @@ public readonly struct ArrayEnumerable<T> : IEnumerable<T, ArrayEnumerator<T>>
 {
     internal ArrayEnumerable(T[] value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public T[] Value { get; }
 
     public ArrayEnumerator<T> GetEnumerator()
     {
-        return new ArrayEnumerator<T>(this.Value);
+        return new ArrayEnumerator<T>(Value);
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/ArrayEnumerator.cs
+++ b/Sample.Struct/Enumerables/ArrayEnumerator.cs
@@ -1,33 +1,40 @@
+namespace Sample.Struct.Enumerables;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Sample.Struct.Enumerables
+public struct ArrayEnumerator<T> : IEnumerator<T>
 {
-    public struct ArrayEnumerator<T> : IEnumerator<T>
+    internal ArrayEnumerator(T[] array)
     {
-        internal ArrayEnumerator(T[] array) => (_i, _array, Current) = (-1, array, default);
+        (this._i, this._array, this.Current) = (-1, array, default);
+    }
 
-        readonly T[] _array;
+    private readonly T[] _array;
 
-        int _i;
+    private int _i;
 
-        public T Current { get; private set; }
+    public T Current { get; private set; }
 
-        object IEnumerator.Current => Current;
+    object IEnumerator.Current => this.Current;
 
-        public void Dispose() { }
+    public void Dispose()
+    {
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MoveNext()
-        {
-            if ((uint)++_i >= (uint)_array.Length)
-                return false;
-            Current = _array[_i];
-            return true;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool MoveNext()
+    {
+        if ((uint)++this._i >= (uint)this._array.Length)
+            return false;
+        this.Current = this._array[this._i];
+        return true;
+    }
 
-        public void Reset() => throw new NotImplementedException();
+    public void Reset()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Sample.Struct/Enumerables/ArrayEnumerator.cs
+++ b/Sample.Struct/Enumerables/ArrayEnumerator.cs
@@ -9,7 +9,7 @@ public struct ArrayEnumerator<T> : IEnumerator<T>
 {
     internal ArrayEnumerator(T[] array)
     {
-        (this._i, this._array, this.Current) = (-1, array, default);
+        (_i, _array, Current) = (-1, array, default);
     }
 
     private readonly T[] _array;
@@ -18,7 +18,7 @@ public struct ArrayEnumerator<T> : IEnumerator<T>
 
     public T Current { get; private set; }
 
-    object IEnumerator.Current => this.Current;
+    object IEnumerator.Current => Current;
 
     public void Dispose()
     {
@@ -27,9 +27,9 @@ public struct ArrayEnumerator<T> : IEnumerator<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
     {
-        if ((uint)++this._i >= (uint)this._array.Length)
+        if ((uint)++_i >= (uint)_array.Length)
             return false;
-        this.Current = this._array[this._i];
+        Current = _array[_i];
         return true;
     }
 

--- a/Sample.Struct/Enumerables/DictionaryEnumerable.cs
+++ b/Sample.Struct/Enumerables/DictionaryEnumerable.cs
@@ -1,25 +1,40 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class DictionaryEnumerable
 {
-    public static class DictionaryEnumerable
+    public static Enumerable<KeyValuePair<TKey, T>, Dictionary<TKey, T>.Enumerator, DictionaryEnumerable<TKey, T>>
+        AsStructEnumerable<TKey, T>
+        (this Dictionary<TKey, T> dictionary)
     {
-        public static Enumerable<KeyValuePair<TKey, T>, Dictionary<TKey, T>.Enumerator, DictionaryEnumerable<TKey, T>> AsStructEnumerable<TKey, T>
-            (this Dictionary<TKey, T> dictionary)
-            => new DictionaryEnumerable<TKey,T>(dictionary);
+        return new DictionaryEnumerable<TKey, T>(dictionary);
+    }
+}
+
+public readonly struct
+    DictionaryEnumerable<TKey, T> : IEnumerable<KeyValuePair<TKey, T>, Dictionary<TKey, T>.Enumerator>
+{
+    internal DictionaryEnumerable(Dictionary<TKey, T> unwrap)
+    {
+        this.Value = unwrap;
     }
 
-    public readonly struct DictionaryEnumerable<TKey, T> : IEnumerable<KeyValuePair<TKey, T>, Dictionary<TKey, T>.Enumerator>
+    public Dictionary<TKey, T> Value { get; }
+
+    public Dictionary<TKey, T>.Enumerator GetEnumerator()
     {
-        internal DictionaryEnumerable(Dictionary<TKey, T> unwrap) => Value = unwrap;
+        return this.Value.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T> Value { get; }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T>.Enumerator GetEnumerator() => Value.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        IEnumerator<KeyValuePair<TKey, T>> IEnumerable<KeyValuePair<TKey, T>>.GetEnumerator() => GetEnumerator();
+    IEnumerator<KeyValuePair<TKey, T>> IEnumerable<KeyValuePair<TKey, T>>.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/DictionaryEnumerable.cs
+++ b/Sample.Struct/Enumerables/DictionaryEnumerable.cs
@@ -18,23 +18,23 @@ public readonly struct
 {
     internal DictionaryEnumerable(Dictionary<TKey, T> unwrap)
     {
-        this.Value = unwrap;
+        Value = unwrap;
     }
 
     public Dictionary<TKey, T> Value { get; }
 
     public Dictionary<TKey, T>.Enumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator<KeyValuePair<TKey, T>> IEnumerable<KeyValuePair<TKey, T>>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/Enumerable.cs
+++ b/Sample.Struct/Enumerables/Enumerable.cs
@@ -1,46 +1,80 @@
-using Sample.Struct.Summators;
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
+using Summators;
 
-namespace Sample.Struct.Enumerables
+public readonly ref struct Linqable<T, TEnumerator, TEnumerable, TOperator>
+    where TEnumerator : IEnumerator<T>
+    where TEnumerable : IEnumerable<T, TEnumerator>
+    where TOperator : ISummator<T, T>
 {
-    public readonly ref struct Linqable<T, TEnumerator, TEnumerable, TOperator>
-        where TEnumerator : IEnumerator<T>
-        where TEnumerable : IEnumerable<T, TEnumerator>
-        where TOperator : ISummator<T, T>
+    private Linqable(TEnumerable value)
     {
-        Linqable(TEnumerable value) => Value = value;
-
-        public TEnumerable Value { get; }
-
-        public TEnumerator GetEnumerator() => Value.GetEnumerator();
-
-        public static implicit operator Linqable<T, TEnumerator, TEnumerable, TOperator>(TEnumerable value) => new Linqable<T, TEnumerator, TEnumerable, TOperator>(value);
-        public static implicit operator TEnumerable(Linqable<T, TEnumerator, TEnumerable, TOperator> value) => value.Value;
+        this.Value = value;
     }
 
-    public readonly ref struct Enumerable<T, TEnumerator, TEnumerable> 
-        where TEnumerator : IEnumerator<T> 
-        where TEnumerable : IEnumerable<T, TEnumerator>
-    {        
-        Enumerable(TEnumerable value) => Value = value;
+    public TEnumerable Value { get; }
 
-        public TEnumerable Value { get; }
-
-        public TEnumerator GetEnumerator() => Value.GetEnumerator();
-
-        public static implicit operator Enumerable<T, TEnumerator, TEnumerable>(TEnumerable value) => new Enumerable<T, TEnumerator, TEnumerable>(value);
-        public static implicit operator TEnumerable(Enumerable<T, TEnumerator, TEnumerable> value) => value.Value;
+    public TEnumerator GetEnumerator()
+    {
+        return this.Value.GetEnumerator();
     }
 
-    public readonly struct Enumerable<T> : IEnumerable<T, IEnumerator<T>>
+    public static implicit operator Linqable<T, TEnumerator, TEnumerable, TOperator>(TEnumerable value)
     {
-        internal Enumerable(IEnumerable<T> unwrap) => Value = unwrap;
+        return new Linqable<T, TEnumerator, TEnumerable, TOperator>(value);
+    }
 
-        public IEnumerable<T> Value { get; }
+    public static implicit operator TEnumerable(Linqable<T, TEnumerator, TEnumerable, TOperator> value)
+    {
+        return value.Value;
+    }
+}
 
-        public IEnumerator<T> GetEnumerator() => Value.GetEnumerator();
+public readonly ref struct Enumerable<T, TEnumerator, TEnumerable>
+    where TEnumerator : IEnumerator<T>
+    where TEnumerable : IEnumerable<T, TEnumerator>
+{
+    private Enumerable(TEnumerable value)
+    {
+        this.Value = value;
+    }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public TEnumerable Value { get; }
+
+    public TEnumerator GetEnumerator()
+    {
+        return this.Value.GetEnumerator();
+    }
+
+    public static implicit operator Enumerable<T, TEnumerator, TEnumerable>(TEnumerable value)
+    {
+        return new Enumerable<T, TEnumerator, TEnumerable>(value);
+    }
+
+    public static implicit operator TEnumerable(Enumerable<T, TEnumerator, TEnumerable> value)
+    {
+        return value.Value;
+    }
+}
+
+public readonly struct Enumerable<T> : IEnumerable<T, IEnumerator<T>>
+{
+    internal Enumerable(IEnumerable<T> unwrap)
+    {
+        this.Value = unwrap;
+    }
+
+    public IEnumerable<T> Value { get; }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        return this.Value.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/Enumerable.cs
+++ b/Sample.Struct/Enumerables/Enumerable.cs
@@ -11,14 +11,14 @@ public readonly ref struct Linqable<T, TEnumerator, TEnumerable, TOperator>
 {
     private Linqable(TEnumerable value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public TEnumerable Value { get; }
 
     public TEnumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     public static implicit operator Linqable<T, TEnumerator, TEnumerable, TOperator>(TEnumerable value)
@@ -38,14 +38,14 @@ public readonly ref struct Enumerable<T, TEnumerator, TEnumerable>
 {
     private Enumerable(TEnumerable value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public TEnumerable Value { get; }
 
     public TEnumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     public static implicit operator Enumerable<T, TEnumerator, TEnumerable>(TEnumerable value)
@@ -63,18 +63,18 @@ public readonly struct Enumerable<T> : IEnumerable<T, IEnumerator<T>>
 {
     internal Enumerable(IEnumerable<T> unwrap)
     {
-        this.Value = unwrap;
+        Value = unwrap;
     }
 
     public IEnumerable<T> Value { get; }
 
     public IEnumerator<T> GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/EnumerableExtensions.cs
+++ b/Sample.Struct/Enumerables/EnumerableExtensions.cs
@@ -1,21 +1,21 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
-namespace Sample.Struct.Enumerables
+public static class EnumerableExtensions
 {
-    public static class EnumerableExtensions
+    public static Enumerable<T, IEnumerator<T>, Enumerable<T>> AsStructEnumerable<T>(this IEnumerable<T> enumerable)
     {
-        public static Enumerable<T, IEnumerator<T>, Enumerable<T>> AsStructEnumerable<T>(this IEnumerable<T> enumerable)
-            => new Enumerable<T>(enumerable);
+        return new Enumerable<T>(enumerable);
+    }
 
-        public static int Sum<TEnumerator, TEnumerable>(this Enumerable<int, TEnumerator, TEnumerable> enumerable)
-            where TEnumerator: IEnumerator<int>
-            where TEnumerable: IEnumerable<int, TEnumerator>
-        {
-            var result = 0;
-            foreach(var i in enumerable)
-                result += i;
-            return result;
-        }
+    public static int Sum<TEnumerator, TEnumerable>(this Enumerable<int, TEnumerator, TEnumerable> enumerable)
+        where TEnumerator : IEnumerator<int>
+        where TEnumerable : IEnumerable<int, TEnumerator>
+    {
+        int result = 0;
+        foreach (int i in enumerable)
+            result += i;
+        return result;
     }
 }

--- a/Sample.Struct/Enumerables/IEnumerable.cs
+++ b/Sample.Struct/Enumerables/IEnumerable.cs
@@ -1,9 +1,8 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public interface IEnumerable<out T, out TEnumerator> : IEnumerable<T> where TEnumerator : IEnumerator<T>
 {
-    public interface IEnumerable<out T, out TEnumerator> : IEnumerable<T> where TEnumerator : IEnumerator<T>
-    {
-        new TEnumerator GetEnumerator();
-    }
+    new TEnumerator GetEnumerator();
 }

--- a/Sample.Struct/Enumerables/KeyCollectionEnumerable.cs
+++ b/Sample.Struct/Enumerables/KeyCollectionEnumerable.cs
@@ -18,23 +18,23 @@ public readonly struct
 {
     internal KeyCollectionEnumerable(Dictionary<TKey, T>.KeyCollection unwrap)
     {
-        this.Value = unwrap;
+        Value = unwrap;
     }
 
     public Dictionary<TKey, T>.KeyCollection Value { get; }
 
     public Dictionary<TKey, T>.KeyCollection.Enumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/KeyCollectionEnumerable.cs
+++ b/Sample.Struct/Enumerables/KeyCollectionEnumerable.cs
@@ -1,25 +1,40 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class KeyCollectionEnumerable
 {
-    public static class KeyCollectionEnumerable
+    public static Enumerable<TKey, Dictionary<TKey, T>.KeyCollection.Enumerator, KeyCollectionEnumerable<TKey, T>>
+        AsStructEnumerable<TKey, T>
+        (this Dictionary<TKey, T>.KeyCollection keys)
     {
-        public static Enumerable<TKey, Dictionary<TKey, T>.KeyCollection.Enumerator, KeyCollectionEnumerable<TKey, T>> AsStructEnumerable<TKey, T>
-            (this Dictionary<TKey, T>.KeyCollection keys)
-            => new KeyCollectionEnumerable<TKey,T>(keys);
+        return new KeyCollectionEnumerable<TKey, T>(keys);
+    }
+}
+
+public readonly struct
+    KeyCollectionEnumerable<TKey, T> : IEnumerable<TKey, Dictionary<TKey, T>.KeyCollection.Enumerator>
+{
+    internal KeyCollectionEnumerable(Dictionary<TKey, T>.KeyCollection unwrap)
+    {
+        this.Value = unwrap;
     }
 
-    public readonly struct KeyCollectionEnumerable<TKey, T> : IEnumerable<TKey, Dictionary<TKey, T>.KeyCollection.Enumerator>
+    public Dictionary<TKey, T>.KeyCollection Value { get; }
+
+    public Dictionary<TKey, T>.KeyCollection.Enumerator GetEnumerator()
     {
-        internal KeyCollectionEnumerable(Dictionary<TKey, T>.KeyCollection unwrap) => Value = unwrap;
+        return this.Value.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T>.KeyCollection Value { get; }
+    IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T>.KeyCollection.Enumerator GetEnumerator() => Value.GetEnumerator();
-
-        IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/ListEnumerable.cs
+++ b/Sample.Struct/Enumerables/ListEnumerable.cs
@@ -15,23 +15,23 @@ public readonly struct ListEnumerable<T> : IEnumerable<T, List<T>.Enumerator>
 {
     internal ListEnumerable(List<T> unwrap)
     {
-        this.Value = unwrap;
+        Value = unwrap;
     }
 
     public List<T> Value { get; }
 
     public List<T>.Enumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/ListEnumerable.cs
+++ b/Sample.Struct/Enumerables/ListEnumerable.cs
@@ -1,24 +1,37 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class ListEnumerable
 {
-    public static class ListEnumerable
+    public static Enumerable<T, List<T>.Enumerator, ListEnumerable<T>> AsStructEnumerable<T>(this List<T> list)
     {
-        public static Enumerable<T, List<T>.Enumerator, ListEnumerable<T>> AsStructEnumerable<T>(this List<T> list)
-            => new ListEnumerable<T>(list);        
+        return new ListEnumerable<T>(list);
+    }
+}
+
+public readonly struct ListEnumerable<T> : IEnumerable<T, List<T>.Enumerator>
+{
+    internal ListEnumerable(List<T> unwrap)
+    {
+        this.Value = unwrap;
     }
 
-    public readonly struct ListEnumerable<T> : IEnumerable<T, List<T>.Enumerator>
+    public List<T> Value { get; }
+
+    public List<T>.Enumerator GetEnumerator()
     {
-        internal ListEnumerable(List<T> unwrap) => Value = unwrap;
+        return this.Value.GetEnumerator();
+    }
 
-        public List<T> Value { get; }
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 
-        public List<T>.Enumerator GetEnumerator() => Value.GetEnumerator();
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    }    
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 }

--- a/Sample.Struct/Enumerables/MemoryEnumerable.cs
+++ b/Sample.Struct/Enumerables/MemoryEnumerable.cs
@@ -1,31 +1,46 @@
-﻿using System;
+﻿namespace Sample.Struct.Enumerables;
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class MemoryEnumerable
 {
-    public static class MemoryEnumerable
+    public static Enumerable<T, MemoryEnumerator<T>, MemoryEnumerable<T>> AsStructEnumerable<T>(this Memory<T> memory)
     {
-        public static Enumerable<T, MemoryEnumerator<T>, MemoryEnumerable<T>> AsStructEnumerable<T>(this Memory<T> memory)
-            => new MemoryEnumerable<T>(memory);
+        return new MemoryEnumerable<T>(memory);
+    }
+}
+
+public readonly struct MemoryEnumerable<T> : IEnumerable<T, MemoryEnumerator<T>>
+{
+    internal MemoryEnumerable(Memory<T> value)
+    {
+        this.Value = value;
     }
 
-    public readonly struct MemoryEnumerable<T> : IEnumerable<T, MemoryEnumerator<T>>
+    public Memory<T> Value { get; }
+
+    public MemoryEnumerator<T> GetEnumerator()
     {
-        internal MemoryEnumerable(Memory<T> value) => Value = value;
-
-        public Memory<T> Value { get; }
-
-        public MemoryEnumerator<T> GetEnumerator() => new MemoryEnumerator<T>(Value);
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        return new MemoryEnumerator<T>(this.Value);
     }
 
-    public static class SpanEnumerable
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        public static SpanEnumerable<T> AsSpanEnumerable<T>(this Span<T> memory)
-            => new SpanEnumerable<T>(memory);
+        return this.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+}
+
+public static class SpanEnumerable
+{
+    public static SpanEnumerable<T> AsSpanEnumerable<T>(this Span<T> memory)
+    {
+        return new SpanEnumerable<T>(memory);
     }
 }

--- a/Sample.Struct/Enumerables/MemoryEnumerable.cs
+++ b/Sample.Struct/Enumerables/MemoryEnumerable.cs
@@ -16,24 +16,24 @@ public readonly struct MemoryEnumerable<T> : IEnumerable<T, MemoryEnumerator<T>>
 {
     internal MemoryEnumerable(Memory<T> value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public Memory<T> Value { get; }
 
     public MemoryEnumerator<T> GetEnumerator()
     {
-        return new MemoryEnumerator<T>(this.Value);
+        return new MemoryEnumerator<T>(Value);
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }
 

--- a/Sample.Struct/Enumerables/MemoryEnumerator.cs
+++ b/Sample.Struct/Enumerables/MemoryEnumerator.cs
@@ -9,7 +9,7 @@ public struct MemoryEnumerator<T> : IEnumerator<T>
 {
     internal MemoryEnumerator(Memory<T> memory)
     {
-        (this._i, this._memory, this.Current) = (-1, memory, default);
+        (_i, _memory, Current) = (-1, memory, default);
     }
 
     private readonly Memory<T> _memory;
@@ -18,7 +18,7 @@ public struct MemoryEnumerator<T> : IEnumerator<T>
 
     public T Current { get; private set; }
 
-    object IEnumerator.Current => this.Current;
+    object IEnumerator.Current => Current;
 
     public void Dispose()
     {
@@ -27,9 +27,9 @@ public struct MemoryEnumerator<T> : IEnumerator<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
     {
-        if ((uint)++this._i >= (uint)this._memory.Length)
+        if ((uint)++_i >= (uint)_memory.Length)
             return false;
-        this.Current = this._memory.Span[this._i];
+        Current = _memory.Span[_i];
         return true;
     }
 

--- a/Sample.Struct/Enumerables/MemoryEnumerator.cs
+++ b/Sample.Struct/Enumerables/MemoryEnumerator.cs
@@ -1,33 +1,40 @@
-﻿using System;
+﻿namespace Sample.Struct.Enumerables;
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Sample.Struct.Enumerables
+public struct MemoryEnumerator<T> : IEnumerator<T>
 {
-    public struct MemoryEnumerator<T> : IEnumerator<T>
+    internal MemoryEnumerator(Memory<T> memory)
     {
-        internal MemoryEnumerator(Memory<T> memory) => (_i, _memory, Current) = (-1, memory, default);
+        (this._i, this._memory, this.Current) = (-1, memory, default);
+    }
 
-        readonly Memory<T> _memory;
+    private readonly Memory<T> _memory;
 
-        int _i;
+    private int _i;
 
-        public T Current { get; private set; }
+    public T Current { get; private set; }
 
-        object IEnumerator.Current => Current;
+    object IEnumerator.Current => this.Current;
 
-        public void Dispose() { }
+    public void Dispose()
+    {
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MoveNext()
-        {
-            if ((uint)++_i >= (uint)_memory.Length)
-                return false;
-            Current = _memory.Span[_i];
-            return true;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool MoveNext()
+    {
+        if ((uint)++this._i >= (uint)this._memory.Length)
+            return false;
+        this.Current = this._memory.Span[this._i];
+        return true;
+    }
 
-        public void Reset() => throw new NotImplementedException();
+    public void Reset()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Sample.Struct/Enumerables/SelectEnumerable.cs
+++ b/Sample.Struct/Enumerables/SelectEnumerable.cs
@@ -52,7 +52,7 @@ public readonly struct
 {
     internal SelectEnumerable(in Enumerable<T, TAtor, TAble> unwrap, TSelector selector)
     {
-        (this.Value, this._selector) = (unwrap.Value, selector);
+        (Value, _selector) = (unwrap.Value, selector);
     }
 
     public TAble Value { get; }
@@ -61,16 +61,16 @@ public readonly struct
 
     public SelectEnumerator<T, TOut, TAtor, TSelector> GetEnumerator()
     {
-        return new SelectEnumerator<T, TOut, TAtor, TSelector>(this.Value.GetEnumerator(), this._selector);
+        return new SelectEnumerator<T, TOut, TAtor, TSelector>(Value.GetEnumerator(), _selector);
     }
 
     IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/SelectEnumerable.cs
+++ b/Sample.Struct/Enumerables/SelectEnumerable.cs
@@ -1,53 +1,76 @@
+namespace Sample.Struct.Enumerables;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using Sample.Struct.Functions;
-using Sample.Struct.Summators;
+using Functions;
+using Summators;
 
-namespace Sample.Struct.Enumerables
+public static class SelectEnumerable
 {
-    public static class SelectEnumerable
+    public static
+        Enumerable<TOut, SelectEnumerator<int, TOut, TAtor, TSelector>,
+            SelectEnumerable<int, TOut, TAtor, TAble, TSelector>> Select<TAtor, TAble, TSelector, TOut, TOperator>
+        (this in Linqable<int, TAtor, TAble, TOperator> enumerable,
+            Func<Function<Id<int>, int, int, TOperator>, Function<TSelector, int, TOut, TOperator>> selector)
+        where TAtor : IEnumerator<int>
+        where TAble : IEnumerable<int, TAtor>
+        where TSelector : IFunc<int, TOut>
+        where TOperator : struct, ISummator<int, int>, ISummator<TOut, TOut>
     {
-        public static Enumerable<TOut, SelectEnumerator<int, TOut, TAtor, TSelector>, SelectEnumerable<int, TOut, TAtor, TAble, TSelector>> Select<TAtor, TAble, TSelector, TOut, TOperator>
-            (this in Linqable<int, TAtor, TAble, TOperator> enumerable, Func<Function<Id<int>, int, int, TOperator>, Function<TSelector, int, TOut, TOperator>> selector)
-            where TAtor : IEnumerator<int>
-            where TAble : IEnumerable<int, TAtor>
-            where TSelector : IFunc<int, TOut>
-            where TOperator : struct, ISummator<int, int>, ISummator<TOut, TOut>
-            => new SelectEnumerable<int, TOut, TAtor, TAble, TSelector>(enumerable.Value, selector(Functions.Id.Function<int, TOperator>()));
-
-        public static Enumerable<TOut, SelectEnumerator<T, TOut, TAtor, Delegate<T, TOut>>, SelectEnumerable<T, TOut, TAtor, TAble, Delegate<T, TOut>>> Select<T, TOut, TAtor, TAble>
-            (this in Enumerable<T, TAtor, TAble> enumerable, Func<T, TOut> selector)
-            where TAtor : IEnumerator<T>
-            where TAble : IEnumerable<T, TAtor>
-            => enumerable.Select(selector.AsStruct());
-
-        public static Enumerable<TOut, SelectEnumerator<T, TOut, TAtor, TSelector>, SelectEnumerable<T, TOut, TAtor, TAble, TSelector>> Select<T, TOut, TAtor, TAble, TSelector>
-            (this in Enumerable<T, TAtor, TAble> enumerable, Function<TSelector, T, TOut> selector)
-            where TAtor : IEnumerator<T>
-            where TAble : IEnumerable<T, TAtor>
-            where TSelector : IFunc<T, TOut>
-            => new SelectEnumerable<T, TOut, TAtor, TAble, TSelector>(enumerable, selector);
+        return new SelectEnumerable<int, TOut, TAtor, TAble, TSelector>(enumerable.Value,
+            selector(Id.Function<int, TOperator>()));
     }
 
-    public readonly struct SelectEnumerable<T, TOut, TAtor, TAble, TSelector> : IEnumerable<TOut, SelectEnumerator<T, TOut, TAtor, TSelector>>
+    public static
+        Enumerable<TOut, SelectEnumerator<T, TOut, TAtor, Delegate<T, TOut>>,
+            SelectEnumerable<T, TOut, TAtor, TAble, Delegate<T, TOut>>> Select<T, TOut, TAtor, TAble>
+        (this in Enumerable<T, TAtor, TAble> enumerable, Func<T, TOut> selector)
+        where TAtor : IEnumerator<T>
+        where TAble : IEnumerable<T, TAtor>
+    {
+        return enumerable.Select(selector.AsStruct());
+    }
+
+    public static
+        Enumerable<TOut, SelectEnumerator<T, TOut, TAtor, TSelector>,
+            SelectEnumerable<T, TOut, TAtor, TAble, TSelector>> Select<T, TOut, TAtor, TAble, TSelector>
+        (this in Enumerable<T, TAtor, TAble> enumerable, Function<TSelector, T, TOut> selector)
         where TAtor : IEnumerator<T>
         where TAble : IEnumerable<T, TAtor>
         where TSelector : IFunc<T, TOut>
     {
-        internal SelectEnumerable(in Enumerable<T, TAtor, TAble> unwrap, TSelector selector)
-            => (Value, _selector) = (unwrap.Value, selector);
+        return new SelectEnumerable<T, TOut, TAtor, TAble, TSelector>(enumerable, selector);
+    }
+}
 
-        public TAble Value { get; }
+public readonly struct
+    SelectEnumerable<T, TOut, TAtor, TAble, TSelector> : IEnumerable<TOut, SelectEnumerator<T, TOut, TAtor, TSelector>>
+    where TAtor : IEnumerator<T>
+    where TAble : IEnumerable<T, TAtor>
+    where TSelector : IFunc<T, TOut>
+{
+    internal SelectEnumerable(in Enumerable<T, TAtor, TAble> unwrap, TSelector selector)
+    {
+        (this.Value, this._selector) = (unwrap.Value, selector);
+    }
 
-        readonly TSelector _selector;
+    public TAble Value { get; }
 
-        public SelectEnumerator<T, TOut, TAtor, TSelector> GetEnumerator()
-            => new SelectEnumerator<T, TOut, TAtor, TSelector>(Value.GetEnumerator(), _selector);
+    private readonly TSelector _selector;
 
-        IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator() => GetEnumerator();
+    public SelectEnumerator<T, TOut, TAtor, TSelector> GetEnumerator()
+    {
+        return new SelectEnumerator<T, TOut, TAtor, TSelector>(this.Value.GetEnumerator(), this._selector);
+    }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/SelectEnumerator.cs
+++ b/Sample.Struct/Enumerables/SelectEnumerator.cs
@@ -10,7 +10,7 @@ public struct SelectEnumerator<T, TOut, TAtor, TSelector> : IEnumerator<TOut>
 {
     internal SelectEnumerator(in TAtor enumerator, TSelector selector)
     {
-        (this._enumerator, this._selector, this.Current) = (enumerator, selector, default);
+        (_enumerator, _selector, Current) = (enumerator, selector, default);
     }
 
     private TAtor _enumerator;
@@ -19,7 +19,7 @@ public struct SelectEnumerator<T, TOut, TAtor, TSelector> : IEnumerator<TOut>
 
     public TOut Current { get; private set; }
 
-    object IEnumerator.Current => this.Current;
+    object IEnumerator.Current => Current;
 
     public void Dispose()
     {
@@ -28,15 +28,15 @@ public struct SelectEnumerator<T, TOut, TAtor, TSelector> : IEnumerator<TOut>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
     {
-        if (!this._enumerator.MoveNext())
+        if (!_enumerator.MoveNext())
             return false;
-        TSelector s = this._selector;
-        this.Current = s.Invoke(this._enumerator.Current);
+        TSelector s = _selector;
+        Current = s.Invoke(_enumerator.Current);
         return true;
     }
 
     public void Reset()
     {
-        this._enumerator.Reset();
+        _enumerator.Reset();
     }
 }

--- a/Sample.Struct/Enumerables/SelectEnumerator.cs
+++ b/Sample.Struct/Enumerables/SelectEnumerator.cs
@@ -1,37 +1,42 @@
-using System;
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Sample.Struct.Enumerables
+public struct SelectEnumerator<T, TOut, TAtor, TSelector> : IEnumerator<TOut>
+    where TAtor : IEnumerator<T>
+    where TSelector : IFunc<T, TOut>
 {
-    public struct SelectEnumerator<T, TOut, TAtor, TSelector> : IEnumerator<TOut>
-        where TAtor : IEnumerator<T>
-        where TSelector : IFunc<T, TOut>
+    internal SelectEnumerator(in TAtor enumerator, TSelector selector)
     {
-        internal SelectEnumerator(in TAtor enumerator, TSelector selector)
-            => (_enumerator, _selector, Current) = (enumerator, selector, default);
+        (this._enumerator, this._selector, this.Current) = (enumerator, selector, default);
+    }
 
-        TAtor _enumerator;
+    private TAtor _enumerator;
 
-        readonly TSelector _selector;
+    private readonly TSelector _selector;
 
-        public TOut Current { get; private set; }
+    public TOut Current { get; private set; }
 
-        object IEnumerator.Current => Current;
+    object IEnumerator.Current => this.Current;
 
-        public void Dispose() { }
+    public void Dispose()
+    {
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MoveNext()
-        {
-            if (!_enumerator.MoveNext())
-                return false;
-            var s = _selector;
-            Current = s.Invoke(_enumerator.Current);
-            return true;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool MoveNext()
+    {
+        if (!this._enumerator.MoveNext())
+            return false;
+        TSelector s = this._selector;
+        this.Current = s.Invoke(this._enumerator.Current);
+        return true;
+    }
 
-        public void Reset() => _enumerator.Reset();
+    public void Reset()
+    {
+        this._enumerator.Reset();
     }
 }

--- a/Sample.Struct/Enumerables/SpanEnumerable.cs
+++ b/Sample.Struct/Enumerables/SpanEnumerable.cs
@@ -1,13 +1,18 @@
-﻿using System;
+﻿namespace Sample.Struct.Enumerables;
 
-namespace Sample.Struct.Enumerables
+using System;
+
+public readonly ref struct SpanEnumerable<T>
 {
-    public readonly ref struct SpanEnumerable<T>
+    internal SpanEnumerable(Span<T> value)
     {
-        internal SpanEnumerable(Span<T> value) => Value = value;
+        this.Value = value;
+    }
 
-        public Span<T> Value { get; }
+    public Span<T> Value { get; }
 
-        public SpanEnumerator<T> GetEnumerator() => new SpanEnumerator<T>(Value);
+    public SpanEnumerator<T> GetEnumerator()
+    {
+        return new SpanEnumerator<T>(this.Value);
     }
 }

--- a/Sample.Struct/Enumerables/SpanEnumerable.cs
+++ b/Sample.Struct/Enumerables/SpanEnumerable.cs
@@ -6,13 +6,13 @@ public readonly ref struct SpanEnumerable<T>
 {
     internal SpanEnumerable(Span<T> value)
     {
-        this.Value = value;
+        Value = value;
     }
 
     public Span<T> Value { get; }
 
     public SpanEnumerator<T> GetEnumerator()
     {
-        return new SpanEnumerator<T>(this.Value);
+        return new SpanEnumerator<T>(Value);
     }
 }

--- a/Sample.Struct/Enumerables/SpanEnumerator.cs
+++ b/Sample.Struct/Enumerables/SpanEnumerator.cs
@@ -1,33 +1,37 @@
-﻿using System;
+﻿namespace Sample.Struct.Enumerables;
+
+using System;
 using System.Runtime.CompilerServices;
 
-namespace Sample.Struct.Enumerables
+public ref struct SpanEnumerator<T>
 {
-    public ref struct SpanEnumerator<T> 
+    internal SpanEnumerator(Span<T> span)
     {
-        internal SpanEnumerator(Span<T> span)
-        {
-            _span = span;
-            (_i, Current) = (-1, default);
-        }
+        this._span = span;
+        (this._i, this.Current) = (-1, default);
+    }
 
-        readonly Span<T> _span;
+    private readonly Span<T> _span;
 
-        int _i;
+    private int _i;
 
-        public T Current { get; private set; }
+    public T Current { get; private set; }
 
-        public void Dispose() { }
+    public void Dispose()
+    {
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MoveNext()
-        {
-            if ((uint)++_i >= (uint)_span.Length)
-                return false;
-            Current = _span[_i];
-            return true;
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool MoveNext()
+    {
+        if ((uint)++this._i >= (uint)this._span.Length)
+            return false;
+        this.Current = this._span[this._i];
+        return true;
+    }
 
-        public void Reset() => throw new NotImplementedException();
+    public void Reset()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Sample.Struct/Enumerables/SpanEnumerator.cs
+++ b/Sample.Struct/Enumerables/SpanEnumerator.cs
@@ -7,8 +7,8 @@ public ref struct SpanEnumerator<T>
 {
     internal SpanEnumerator(Span<T> span)
     {
-        this._span = span;
-        (this._i, this.Current) = (-1, default);
+        _span = span;
+        (_i, Current) = (-1, default);
     }
 
     private readonly Span<T> _span;
@@ -24,9 +24,9 @@ public ref struct SpanEnumerator<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool MoveNext()
     {
-        if ((uint)++this._i >= (uint)this._span.Length)
+        if ((uint)++_i >= (uint)_span.Length)
             return false;
-        this.Current = this._span[this._i];
+        Current = _span[_i];
         return true;
     }
 

--- a/Sample.Struct/Enumerables/ValueCollectionEnumerable.cs
+++ b/Sample.Struct/Enumerables/ValueCollectionEnumerable.cs
@@ -18,23 +18,23 @@ public readonly struct
 {
     internal ValueCollectionEnumerable(Dictionary<TKey, T>.ValueCollection unwrap)
     {
-        this.Value = unwrap;
+        Value = unwrap;
     }
 
     public Dictionary<TKey, T>.ValueCollection Value { get; }
 
     public Dictionary<TKey, T>.ValueCollection.Enumerator GetEnumerator()
     {
-        return this.Value.GetEnumerator();
+        return Value.GetEnumerator();
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/ValueCollectionEnumerable.cs
+++ b/Sample.Struct/Enumerables/ValueCollectionEnumerable.cs
@@ -1,25 +1,40 @@
+namespace Sample.Struct.Enumerables;
+
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class ValueCollectionEnumerable
 {
-    public static class ValueCollectionEnumerable
+    public static Enumerable<T, Dictionary<TKey, T>.ValueCollection.Enumerator, ValueCollectionEnumerable<TKey, T>>
+        AsStructEnumerable<TKey, T>
+        (this Dictionary<TKey, T>.ValueCollection keys)
     {
-        public static Enumerable<T, Dictionary<TKey, T>.ValueCollection.Enumerator, ValueCollectionEnumerable<TKey, T>> AsStructEnumerable<TKey, T>
-            (this Dictionary<TKey, T>.ValueCollection keys)
-            => new ValueCollectionEnumerable<TKey,T>(keys);
+        return new ValueCollectionEnumerable<TKey, T>(keys);
+    }
+}
+
+public readonly struct
+    ValueCollectionEnumerable<TKey, T> : IEnumerable<T, Dictionary<TKey, T>.ValueCollection.Enumerator>
+{
+    internal ValueCollectionEnumerable(Dictionary<TKey, T>.ValueCollection unwrap)
+    {
+        this.Value = unwrap;
     }
 
-    public readonly struct ValueCollectionEnumerable<TKey, T> : IEnumerable<T, Dictionary<TKey, T>.ValueCollection.Enumerator>
+    public Dictionary<TKey, T>.ValueCollection Value { get; }
+
+    public Dictionary<TKey, T>.ValueCollection.Enumerator GetEnumerator()
     {
-        internal ValueCollectionEnumerable(Dictionary<TKey, T>.ValueCollection unwrap) => Value = unwrap;
+        return this.Value.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T>.ValueCollection Value { get; }
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 
-        public Dictionary<TKey, T>.ValueCollection.Enumerator GetEnumerator() => Value.GetEnumerator();
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/WhereEnumerable.cs
+++ b/Sample.Struct/Enumerables/WhereEnumerable.cs
@@ -1,34 +1,45 @@
+namespace Sample.Struct.Enumerables;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public static class WhereEnumerable
 {
-    public static class WhereEnumerable
+    public static Enumerable<T, WhereEnumerator<T, TAtor>, WhereEnumerable<T, TAtor, TAble>> Where<T, TAtor, TAble>
+        (this in Enumerable<T, TAtor, TAble> enumerable, Func<T, bool> predicate)
+        where TAtor : IEnumerator<T>
+        where TAble : IEnumerable<T, TAtor>
     {
-        public static Enumerable<T, WhereEnumerator<T, TAtor>, WhereEnumerable<T, TAtor, TAble>> Where<T, TAtor, TAble>
-            (this in Enumerable<T, TAtor, TAble> enumerable, Func<T, bool> predicate)
-            where TAtor: IEnumerator<T>
-            where TAble: IEnumerable<T, TAtor>
-            => new WhereEnumerable<T, TAtor, TAble>(enumerable, predicate);        
+        return new WhereEnumerable<T, TAtor, TAble>(enumerable, predicate);
+    }
+}
+
+public readonly struct WhereEnumerable<T, TAtor, TAble> : IEnumerable<T, WhereEnumerator<T, TAtor>>
+    where TAtor : IEnumerator<T>
+    where TAble : IEnumerable<T, TAtor>
+{
+    internal WhereEnumerable(in Enumerable<T, TAtor, TAble> unwrap, Func<T, bool> predicate)
+    {
+        (this.Value, this._predicate) = (unwrap.Value, predicate);
     }
 
-    public readonly struct WhereEnumerable<T, TAtor, TAble> : IEnumerable<T, WhereEnumerator<T, TAtor>>
-        where TAtor: IEnumerator<T>
-        where TAble: IEnumerable<T, TAtor>
+    public TAble Value { get; }
+
+    private readonly Func<T, bool> _predicate;
+
+    public WhereEnumerator<T, TAtor> GetEnumerator()
     {
-        internal WhereEnumerable(in Enumerable<T, TAtor, TAble> unwrap, Func<T, bool> predicate) 
-            => (Value, _predicate) = (unwrap.Value, predicate);
+        return new WhereEnumerator<T, TAtor>(this.Value.GetEnumerator(), this._predicate);
+    }
 
-        public TAble Value { get; }
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 
-        readonly Func<T, bool> _predicate;
-
-        public WhereEnumerator<T, TAtor> GetEnumerator() 
-            => new WhereEnumerator<T, TAtor>(Value.GetEnumerator(), _predicate);
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    }    
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
 }

--- a/Sample.Struct/Enumerables/WhereEnumerable.cs
+++ b/Sample.Struct/Enumerables/WhereEnumerable.cs
@@ -21,7 +21,7 @@ public readonly struct WhereEnumerable<T, TAtor, TAble> : IEnumerable<T, WhereEn
 {
     internal WhereEnumerable(in Enumerable<T, TAtor, TAble> unwrap, Func<T, bool> predicate)
     {
-        (this.Value, this._predicate) = (unwrap.Value, predicate);
+        (Value, _predicate) = (unwrap.Value, predicate);
     }
 
     public TAble Value { get; }
@@ -30,16 +30,16 @@ public readonly struct WhereEnumerable<T, TAtor, TAble> : IEnumerable<T, WhereEn
 
     public WhereEnumerator<T, TAtor> GetEnumerator()
     {
-        return new WhereEnumerator<T, TAtor>(this.Value.GetEnumerator(), this._predicate);
+        return new WhereEnumerator<T, TAtor>(Value.GetEnumerator(), _predicate);
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return this.GetEnumerator();
+        return GetEnumerator();
     }
 }

--- a/Sample.Struct/Enumerables/WhereEnumerator.cs
+++ b/Sample.Struct/Enumerables/WhereEnumerator.cs
@@ -1,36 +1,42 @@
+namespace Sample.Struct.Enumerables;
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Sample.Struct.Enumerables
+public struct WhereEnumerator<T, TAtor> : IEnumerator<T>
+    where TAtor : IEnumerator<T>
 {
-    public struct WhereEnumerator<T, TAtor> : IEnumerator<T>
-        where TAtor : IEnumerator<T>
+    internal WhereEnumerator(in TAtor enumerator, Func<T, bool> predicate)
     {
-        internal WhereEnumerator(in TAtor enumerator, Func<T, bool> predicate)
-            => (_enumerator, _predicate) = (enumerator, predicate);
+        (this._enumerator, this._predicate) = (enumerator, predicate);
+    }
 
-        TAtor _enumerator;
+    private TAtor _enumerator;
 
-        readonly Func<T, bool> _predicate;
+    private readonly Func<T, bool> _predicate;
 
-        public T Current => _enumerator.Current;
+    public T Current => this._enumerator.Current;
 
-        object IEnumerator.Current => Current;
+    object IEnumerator.Current => this.Current;
 
-        public void Dispose() { }
+    public void Dispose()
+    {
+    }
 
-        public bool MoveNext()
+    public bool MoveNext()
+    {
+        do
         {
-            do
-            {
-                if (!_enumerator.MoveNext())
-                    return false;
-            }
-            while (!_predicate(_enumerator.Current));
-            return true;
-        }
+            if (!this._enumerator.MoveNext())
+                return false;
+        } while (!this._predicate(this._enumerator.Current));
 
-        public void Reset() => _enumerator.Reset();
+        return true;
+    }
+
+    public void Reset()
+    {
+        this._enumerator.Reset();
     }
 }

--- a/Sample.Struct/Enumerables/WhereEnumerator.cs
+++ b/Sample.Struct/Enumerables/WhereEnumerator.cs
@@ -9,16 +9,16 @@ public struct WhereEnumerator<T, TAtor> : IEnumerator<T>
 {
     internal WhereEnumerator(in TAtor enumerator, Func<T, bool> predicate)
     {
-        (this._enumerator, this._predicate) = (enumerator, predicate);
+        (_enumerator, _predicate) = (enumerator, predicate);
     }
 
     private TAtor _enumerator;
 
     private readonly Func<T, bool> _predicate;
 
-    public T Current => this._enumerator.Current;
+    public T Current => _enumerator.Current;
 
-    object IEnumerator.Current => this.Current;
+    object IEnumerator.Current => Current;
 
     public void Dispose()
     {
@@ -28,15 +28,15 @@ public struct WhereEnumerator<T, TAtor> : IEnumerator<T>
     {
         do
         {
-            if (!this._enumerator.MoveNext())
+            if (!_enumerator.MoveNext())
                 return false;
-        } while (!this._predicate(this._enumerator.Current));
+        } while (!_predicate(_enumerator.Current));
 
         return true;
     }
 
     public void Reset()
     {
-        this._enumerator.Reset();
+        _enumerator.Reset();
     }
 }


### PR DESCRIPTION
- Tweaked `.editorconfig` to not place `this.` and `Me.`
- Moved all in `Sample.Struct/Enumerables/*.cs` to a scoped namespace.